### PR TITLE
Support node 0.4 and latest npm.

### DIFF
--- a/lib/form2json.js
+++ b/lib/form2json.js
@@ -95,6 +95,4 @@ exports.transform = function(obj) {
 
 var rplus = /\+/g;
 
-exports.unescape = function(s) {
-	return process.binding("http_parser").urlDecode(s).replace(rplus, ' ');
-};
+exports.unescape = require('querystring').unescape;

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
-	name: "form2json",
-	version: "0.0.2",
-	description: "Alternative decoder for form-urlencoded data",
-	homepage: "http://github.com/fgnass/form2json",
-	author: {
-		name: "Felix Gnass",
-		email: "felix.gnass@neteye.de",
-		url: "http://fgnass.posterous.com"
+	"name": "form2json",
+	"version": "0.0.2",
+	"description": "Alternative decoder for form-urlencoded data",
+	"homepage": "http://github.com/fgnass/form2json",
+	"author": {
+		"name": "Felix Gnass",
+		"email": "felix.gnass@neteye.de",
+		"url": "http://fgnass.posterous.com"
 	},
-	keywords: ["form", "urlencoded", "bodyDecoder", "querystring"],
-	main: "./index.js",
-	repository: {
+	"keywords": ["form", "urlencoded", "bodyDecoder", "querystring"],
+	"main": "./index.js",
+	"repository": {
 		"type": "git",
 		"url" : "http://github.com/fgnass/form2json.git"
 	}


### PR DESCRIPTION
Latest npm uses stricter json parsing and is failing on the package.json file.

Also, the bound unescape function that is referenced no longer exists. I use the unescape function in the querystring module. Not sure about the rplus replace.
