### PR TITLE
Updated package.json to work with NPM version 1.1.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
-	name: "form2json",
-	version: "0.0.2",
-	description: "Alternative decoder for form-urlencoded data",
-	homepage: "http://github.com/fgnass/form2json",
-	author: {
-		name: "Felix Gnass",
-		email: "felix.gnass@neteye.de",
-		url: "http://fgnass.posterous.com"
+	"name": "form2json",
+	"version": "0.0.2",
+	"description": "Alternative decoder for form-urlencoded data",
+	"homepage": "http://github.com/fgnass/form2json",
+	"author": {
+		"name": "Felix Gnass",
+		"email": "felix.gnass@neteye.de",
+		"url": "http://fgnass.posterous.com"
 	},
-	keywords: ["form", "urlencoded", "bodyDecoder", "querystring"],
-	main: "./index.js",
-	repository: {
+	"keywords": ["form", "urlencoded", "bodyDecoder", "querystring"],
+	"main": "./index.js",
+	"repository": {
 		"type": "git",
 		"url" : "http://github.com/fgnass/form2json.git"
 	}


### PR DESCRIPTION
Was getting an error in NPM version 1.1.19  

It was complaining about the format of the json package.

---
## Error

$ npm install form2json

npm http GET https://registry.npmjs.org/form2json
npm http 304 https://registry.npmjs.org/form2json
npm http GET https://registry.npmjs.org/form2json/-/form2json-0.0.2.tgz

npm ERR! Failed to parse json
npm ERR! Unexpected token n
npm ERR! File: /tmp/npm-1338398547699/1338398547699-0.7006723647937179/package/package.json
npm ERR! JSON.parse Failed to parse package.json data.
npm ERR! JSON.parse package.json must be actual JSON, not just JavaScript.
npm ERR! JSON.parse 
npm ERR! JSON.parse This is not a bug in npm.
npm ERR! JSON.parse Tell the package author to fix their package.json file.
npm ERR! 
npm ERR! System Linux 3.3.0-8.fc16.x86_64
npm ERR! command "nodejs" "/usr/bin/npm" "install" "form2json"
npm ERR! cwd /home/sstent/node/store
npm ERR! node -v v0.6.17
npm ERR! npm -v 1.1.19
npm ERR! file /tmp/npm-1338398547699/1338398547699-0.7006723647937179/package/package.json
npm ERR! code EJSONPARSE
npm ERR! message Failed to parse json
npm ERR! message Unexpected token n
npm ERR! errno {}
npm ERR! 
npm ERR! Additional logging details can be found in:
npm ERR!     /home/sstent/node/store/npm-debug.log
npm not ok
